### PR TITLE
Easier to add UIContainer children

### DIFF
--- a/src/UI.h
+++ b/src/UI.h
@@ -2,7 +2,7 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <vulkan/vulkan.hpp>
+#include <vulkan.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
@@ -168,7 +168,7 @@ public:
 		display(UI_DISPLAY_FLAG_SHOW) {}
 	UIComponent(const UIComponent& rhs) :
 		pcdata(rhs.pcdata),
-		graphicspipeline(defaultgraphicspipeline),
+		graphicspipeline(rhs.graphicspipeline),
 		drawFunc(rhs.drawFunc),
 		onHover(rhs.onHover),
 		onHoverBegin(rhs.onHoverBegin),
@@ -260,12 +260,15 @@ public:
 	 * This template function is a little hack to get the appropriate contructor called for classes like
 	 * UIText, which needs to monitor how many objects are using which texture. Implicitly, T should
 	 * only be a UIComponent inheritor, I'm unsure if there is a way to enforce this.
+	 *
+	 * It returns the heap-alloc'd pointer for further ops. Allows for a UIHandler to keep all these pointers straight itself if it needs to, without overhead in here.
 	 */
 	template<class T>
-	void addChild(const T& c) {
+	T* addChild(const T& c) {
 		T* temp = new T;
 		*temp = c;
 		children.push_back(dynamic_cast<UIComponent*>(temp));
+		return temp;
 	}
 
 private:


### PR DESCRIPTION
addChild returns a pointer to the new heap alloc'd child for a handler to manage, and graphicspipeline is set to the parent's in the copy constructor.